### PR TITLE
Add peanuts to water comparisons

### DIFF
--- a/src/data/energyData.js
+++ b/src/data/energyData.js
@@ -176,7 +176,7 @@ export const lifestyleEquivalents = {
       // Reference: https://peanutbureau.ca/the-water-footprint-of-peanuts
       name: "Peanut",
       emoji: "🥜",
-      value: 0.1, // Gallons; based on 3.2 gal/oz and 30 peanuts/oz
+      value: 0.11, // Gallons; based on 3.2 gal/oz and 30 peanuts/oz
       unit: {
         singular: "peanut",
         plural: "peanuts"

--- a/src/data/energyData.js
+++ b/src/data/energyData.js
@@ -176,7 +176,7 @@ export const lifestyleEquivalents = {
       // Reference: https://peanutbureau.ca/the-water-footprint-of-peanuts
       name: "Peanut",
       emoji: "🥜",
-      value: 0.11, // Gallons; based on 3.2 gal/oz and 30 peanuts/oz
+      value: 0.11, // Gallons; based on 3.2 gal/oz and 28-30 peanuts/oz
       unit: {
         singular: "peanut",
         plural: "peanuts"

--- a/src/data/energyData.js
+++ b/src/data/energyData.js
@@ -171,6 +171,17 @@ export const lifestyleEquivalents = {
         plural: "cups"
       },
       description: "Producing one cup of rice"
+    },
+    peanut: {
+      // Reference: https://peanutbureau.ca/the-water-footprint-of-peanuts
+      name: "Peanut",
+      emoji: "🥜",
+      value: 0.1, // Gallons; based on 3.2 gal/oz and 30 peanuts/oz
+      unit: {
+        singular: "peanut",
+        plural: "peanuts"
+      },
+      description: "Producing one peanut"
     }
   }
 };

--- a/src/data/energyData.js
+++ b/src/data/energyData.js
@@ -181,7 +181,7 @@ export const lifestyleEquivalents = {
         singular: "peanut",
         plural: "peanuts"
       },
-      description: "Producing one peanut"
+      description: "Producing one whole peanut (two halves)"
     }
   }
 };

--- a/src/data/energyData.js
+++ b/src/data/energyData.js
@@ -173,10 +173,11 @@ export const lifestyleEquivalents = {
       description: "Producing one cup of rice"
     },
     peanut: {
-      // Reference: https://peanutbureau.ca/the-water-footprint-of-peanuts
+      // Water reference: https://peanutbureau.ca/the-water-footprint-of-peanuts
+      // Per-peanut weight reference: https://health.clevelandclinic.org/benefits-of-nuts
       name: "Peanut",
       emoji: "🥜",
-      value: 0.11, // Gallons; based on 3.2 gal/oz and 28-30 peanuts/oz
+      value: 0.1, // Gallons; based on 3.2 gal/oz and 35 peanuts/oz
       unit: {
         singular: "peanut",
         plural: "peanuts"


### PR DESCRIPTION
Producing 1 ounce of peanuts consumes 3.2 ounces of water, per the [Peanut Bureau of Canada](https://peanutbureau.ca/the-water-footprint-of-peanuts) and the [National Peanut Board](https://nationalpeanutboard.org/news/new-data-confirms-peanuts-are-more-water-efficient-than-ever/).

The number of peanuts per ounce is inconsistently documented; most websites suggest 28-30 peanuts per ounce, but [the Cleveland Clinic says there are 35 peanuts per ounce](https://health.clevelandclinic.org/benefits-of-nuts), and they seem like a better authority than random websites (and it makes for a more conservative estimate).